### PR TITLE
Handle slug fallback when recipe tokens are empty

### DIFF
--- a/lib/recipe_poster/run.rb
+++ b/lib/recipe_poster/run.rb
@@ -195,15 +195,23 @@ module RecipePoster
       end
 
       tokens = tokens.map { |t| ascii_slugify(t) }.reject(&:empty?).uniq
+
+      # 4) すべて空ならフォールバック： meal頭文字 + 短いハッシュ
+      if tokens.empty?
+        digest = Digest::SHA1.hexdigest(recipe["title"].to_s)[0, 6]
+        base = "#{meal[0]}-#{digest}"
+        return ensure_unique_slug(base, max_len: max_len)
+      end
+
       base = ([meal[0]] + tokens).join("-") # 例: "d-cold-pasta"
       slug = ensure_unique_slug(base, max_len: max_len)
 
-      # 4) すべて空ならフォールバック： meal頭文字 + 短いハッシュ
       if slug.nil? || slug.empty?
         digest = Digest::SHA1.hexdigest(recipe["title"].to_s)[0, 6]
-        slug = "#{meal[0]}-#{digest}"
+        ensure_unique_slug("#{meal[0]}-#{digest}", max_len: max_len)
+      else
+        slug
       end
-      slug
     end
 
     def hashtagify(str)


### PR DESCRIPTION
## Summary
- ensure slug generation falls back to a meal-prefixed hash when no tokens are available
- reuse unique slug logic for the fallback to avoid collisions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c17ad5b0832cb412d8575b31e907