### PR TITLE
Handle slug fallback when recipe tokens are empty and add trivia to posts

### DIFF
--- a/lib/recipe_poster/llm.rb
+++ b/lib/recipe_poster/llm.rb
@@ -28,6 +28,7 @@ module RecipePoster
         * 避けたい料理名: #{avoid_titles.join(", ")}
         * 避けたい主材料: #{avoid_ingredients.join(", ")}
         * 避けたい調理法: #{avoid_methods.join(", ")}
+      - 作る料理または主要な食材に関する豆知識を1つ、100字以内で添える。
 
       # 出力は必ず JSON（UTF-8）で。キー厳守
       {
@@ -41,6 +42,7 @@ module RecipePoster
         "nutrition": {"kcal": integer, "protein_g": integer, "fat_g": integer, "carb_g": integer},
         "slug_tokens_en": [string, ...],
         "hashtags": [string, ...],
+        "trivia": string,
 
         // 多様性メタ（新規）
         "primary_ingredient": string, // 例: 鶏むね肉 / 豚こま / 豆腐 / そうめん
@@ -123,6 +125,7 @@ module RecipePoster
       - 日本の家庭で作りやすい（手に入る食材、道具）
       - 季節感・気温に合う献立（暑い日はさっぱり・冷たい、寒い日は温かい・滋養 など）
       - 1品で主菜になること。所要時間は45分以内目標
+      - 料理または主要な食材についての豆知識を1つ、100字以内で必ず含める。
 
       # 出力は必ずJSON（UTF-8, 改行含む）で（キー名厳守）
       {
@@ -135,7 +138,8 @@ module RecipePoster
         "tips": [string, ...],
         "slug_tokens_en": [string, ...],
         "nutrition": {"kcal": integer, "protein_g": integer, "fat_g": integer, "carb_g": integer},
-        "hashtags": [string, ...]
+        "hashtags": [string, ...],
+        "trivia": string
       }
       PROMPT
     end

--- a/lib/recipe_poster/run.rb
+++ b/lib/recipe_poster/run.rb
@@ -195,15 +195,23 @@ module RecipePoster
       end
 
       tokens = tokens.map { |t| ascii_slugify(t) }.reject(&:empty?).uniq
+
+      # 4) すべて空ならフォールバック： meal頭文字 + 短いハッシュ
+      if tokens.empty?
+        digest = Digest::SHA1.hexdigest(recipe["title"].to_s)[0, 6]
+        base = "#{meal[0]}-#{digest}"
+        return ensure_unique_slug(base, max_len: max_len)
+      end
+
       base = ([meal[0]] + tokens).join("-") # 例: "d-cold-pasta"
       slug = ensure_unique_slug(base, max_len: max_len)
 
-      # 4) すべて空ならフォールバック： meal頭文字 + 短いハッシュ
       if slug.nil? || slug.empty?
         digest = Digest::SHA1.hexdigest(recipe["title"].to_s)[0, 6]
-        slug = "#{meal[0]}-#{digest}"
+        ensure_unique_slug("#{meal[0]}-#{digest}", max_len: max_len)
+      else
+        slug
       end
-      slug
     end
 
     def hashtagify(str)

--- a/lib/recipe_poster/wordpress.rb
+++ b/lib/recipe_poster/wordpress.rb
@@ -174,6 +174,12 @@ module RecipePoster
       clean_steps = Array(recipe["steps"]).map { |s| strip_step_prefix(s) }
       steps_html  = clean_steps.map { |s| "<li>#{s}</li>" }.join
       tips      = (recipe["tips"] || []).map { |t| "<li>#{t}</li>" }.join
+      trivia    = recipe["trivia"].to_s.strip
+      trivia_html = if trivia.empty?
+        ""
+      else
+        %Q{          <h2>豆知識</h2>\n          <p class="rp-trivia">#{trivia}</p>\n}
+      end
 
       # === JSON-LD を構築 ===
       require "json"
@@ -232,6 +238,7 @@ module RecipePoster
 
           <h2>概要</h2>
           <p>#{recipe["summary"]}</p>
+#{trivia_html}
           <ul class="rp-meta">
           <li>想定人数: #{recipe["servings"]}人分</li>
             <li>調理時間: 約#{recipe["time_minutes"]}分</li>

--- a/lib/recipe_poster/wordpress.rb
+++ b/lib/recipe_poster/wordpress.rb
@@ -170,7 +170,6 @@ module RecipePoster
 
     def build_html(recipe, meta)
       ing_lines = recipe["ingredients"].map { |i| "<li>#{i["item"]} – #{i["amount"]}</li>" }.join
-      steps     = recipe["steps"].each_with_index.map { |s, i| "<li>#{i + 1}. #{s}</li>" }.join
       clean_steps = Array(recipe["steps"]).map { |s| strip_step_prefix(s) }
       steps_html  = clean_steps.map { |s| "<li>#{s}</li>" }.join
       tips      = (recipe["tips"] || []).map { |t| "<li>#{t}</li>" }.join
@@ -178,7 +177,11 @@ module RecipePoster
       trivia_html = if trivia.empty?
         ""
       else
-        %Q{          <h2>豆知識</h2>\n          <p class="rp-trivia">#{trivia}</p>\n}
+        section = <<~HTML
+          <h2>豆知識</h2>
+          <p class="rp-trivia">#{trivia}</p>
+        HTML
+        section.lines.map { |line| "          #{line}" }.join
       end
 
       # === JSON-LD を構築 ===


### PR DESCRIPTION
## Summary
- ensure slug generation falls back to a meal-prefixed hash when no tokens are available
- reuse unique slug logic for the fallback to avoid collisions
- request and render a trivia blurb about the recipe or ingredients in generated posts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c17ad5b0832cb412d8575b31e907